### PR TITLE
check_bundle allows type String, defaults config to {}

### DIFF
--- a/resources/check_bundle.rb
+++ b/resources/check_bundle.rb
@@ -3,10 +3,10 @@ attribute :display_name, :name_attribute
 attribute :target
 attribute :timeout, :kind_of => Integer, :default => 10
 attribute :period, :kind_of => Integer, :default => 60
-attribute :type, { :required => true, :kind_of => Symbol }
+attribute :type, { :required => true, :kind_of => [Symbol, String] }
 attribute :brokers
 attribute :id, :kind_of => String, :regex => /^\d+$/
-attribute :config, :kind_of => Hash
+attribute :config, :kind_of => Hash, :default => {}
 
 # TODO - these should be private or readonly
 attribute :exists, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
- when using type "json:nad", a symbol does not make sense. Since it's
  being converted to a string in the API call, why not just allow String
  as a type?
- default config to {} if not present. For checks that require a config,
  this gives more useful error messages about invalid configs instead of
  about invalid JSON.
