### PR TITLE
Add alpha attribute to graph datapoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Resource Attributes:
     * broker - name of the broker, used to identify the check
     * axis - :r or :l, which axis the the data should be measured against
     * color - #FF00FF style; if omitted, circonus server will provide a default
+    * alpha - float or integer; 0 - 1; defaults to 0.3
     * data_formula - see web UI help; may be left null
     * legend_formula - see web UI help; may be left null
     * hidden - true/false, false default

--- a/providers/graph_datapoint.rb
+++ b/providers/graph_datapoint.rb
@@ -101,6 +101,7 @@ def any_payload_changes?
   new_payload['alpha'] = new_payload['alpha'].nil? ? 'ff' : new_payload['alpha']
   
   fields = [
+            'alpha',
             'axis',
             'data_formula',
             'color',

--- a/resources/graph_datapoint.rb
+++ b/resources/graph_datapoint.rb
@@ -3,6 +3,8 @@ actions :create #, :delete # TODO
 attribute :graph
 attribute :broker # We identify checks by broker
 attribute :metric # name of the chef circonus_metric resource
+attribute :alpha, :kind_of => Numeric, :default => 0.3,
+    :callbacks => {"should be a number between 0 and 1" => lambda {|i| self.validate_alpha(i) } }
 attribute :axis, :kind_of => Symbol, :equal_to => [:r, :l], :default => :l
 attribute :color, :kind_of => String, :regex => /^\#[0-9a-fA-F]{6}$/
 attribute :data_formula 
@@ -37,10 +39,11 @@ end
    #  "name"=>"Out Errors",
    #  "stack"=>nil},
 
-def to_payload_hash 
+def to_payload_hash
   payload = Hash.new()
 
   fields = [
+            'alpha',
             'axis',
             'check_id',
             'color',
@@ -72,4 +75,10 @@ def to_payload_hash
 
   return payload
 
+end
+
+private
+
+def self.validate_alpha(i)
+  i >= 0 && i <= 1
 end


### PR DESCRIPTION
I put the default at 0.3 because that appears to be the default for new datapoints in the web UI. I figured it was better for the cookbook to be explicit, but that seems open to other opinions.
