### PR TITLE
Missing value from check_type_nad.

### DIFF
--- a/libraries/check_type_nad.rb
+++ b/libraries/check_type_nad.rb
@@ -38,6 +38,7 @@ class Circonus
             flattened[full_name.to_sym] = {
               :label => full_name,  # No way of knowing a prettier name
               :type  => NAD_TYPE_TO_CIRCONUS_TYPE[check_details['_type']],
+              :value  => check_details['_value']
             }
           end
         end


### PR DESCRIPTION
This is useful for things like filesystem block sizes in building graphs, etc..
