### PR TITLE
Allow :auto and :guess as targets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+2013-11-12 v0.0.12 mark at omniti dot com
+  * Allow :auto and :guess as targets to use ohai and guess_main_ip() respectively.
+
 2013-10-22 v0.0.11 clinton at omniti dot com
   * Return values from metric scanner
   * Cache mechanism overhaul (David Nicklay)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Actions:
 Resource Attributes:
 
     * display_name - Display name of bundle, will appear in email subjects.  Uses resource name if not provided.
-    * target - Hostname or IP to query.  Defaults to node[:circonus][:target], which defaults to the node's guess_main_ip() according to NetInfo.
+    * target - Hostname or IP to query.  Defaults to node[:circonus][:target], which in turn defaults to the node's guess_main_ip() according to NetInfo. If NetInfo isn't present, then it defaults to node[:ipaddress].
     * type - Type of check, like :resmon or :http    
     * brokers - Array of broker names.  Defaults to node[:circonus][:default_brokers]
     * tags - Array of freeform strings to be used as tags in the web UI.  Default [ ] 
@@ -240,7 +240,7 @@ Currently very few check types are supported by MetricScanner - only ping and na
         :api_token => 'some-string-here',  # Required - see  https://circonus.com/resources/api#authentication
         # Note: app_token is a deprecated alias for api_token
 
-        :target => 'your-ip',           # By default, uses value of node[:fqdn]
+        :target => 'your-ip',           # By default, uses guess_main_ip() or node[:ipaddress], specify :guess or :auto to force one of these methods.
         :default_brokers => [ ],           # List of names of brokers, like 'agent-il-1', to use when creating check bundles        
 
         # Path to a directory in which we will cache circonus config data
@@ -327,7 +327,7 @@ The main repo is at https://github.com/omniti-labs/circonus-cookbook - please fo
 ## Contributors
 
   Eric Saxby
-
+  Mark Harrison
 
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
     "license":"All rights reserved",
     "description":"Circonus API client lib, resources, and such",
     "long_description":"Client interface to the Circonus monitoring, alerting, and trending system.  Provides resources for registering checks, metrics, rules, and graphs.",
-    "version":"0.0.11",
+    "version":"0.0.12",
     "name":"circonus"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email "sa@omniti.com"
 license          "All rights reserved"
 description      "Circonus API client lib, resources, and such"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.11"
+version          "0.0.12"
 name             "circonus"

--- a/providers/check_bundle.rb
+++ b/providers/check_bundle.rb
@@ -8,9 +8,22 @@ def load_current_resource
   # Apply defaults to the desired state
   # TODO - should this be in the resource initialize() ?
   unless @new_resource.target then 
-    if self.respond_to?(:guess_main_ip) then
-      tgt = node['circonus']['target'].empty? ? guess_main_ip() : node['circonus']['target']
+    if node['circonus']['target'] == :guess then
+      # Force guess_main_ip
+      tgt = guess_main_ip()
+    elsif node['circonus']['target'] == :auto then
+      # Force ohai ip address
+      tgt = node[:ipaddress]
+    elsif node['circonus']['target'].empty? then
+      # If we didn't specify anything, use guess_main_ip if available,
+      # otherwise use ohai
+      if self.respond_to?(:guess_main_ip) then
+        tgt = guess_main_ip()
+      else
+        tgt = node[:ipaddress]
+      end
     else
+      # If we specified an explicit target, then use it
       tgt = node['circonus']['target']
     end
     @new_resource.target(tgt)


### PR DESCRIPTION
These will use node[:ipaddress] and guess_main_ip respectively.

Also, if node[:circonus][:target] is empty and guess_main_ip isn't available,
then use node[:ipaddress] as the IP.
