### PR TITLE
Pass JSON values back from metrics scanner

### DIFF
--- a/libraries/check_type_json.rb
+++ b/libraries/check_type_json.rb
@@ -46,6 +46,7 @@ class Circonus
           scan[metric_name] = {
             :label => metric_name, # No way of knowing a prettier name
             :type => value =~ /^\d+(\.\d+)?$/ ? :numeric : :text,
+            :value => value
           }
         end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email "sa@omniti.com"
 license          "All rights reserved"
 description      "Circonus API client lib, resources, and such"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.12"
+version          "0.0.13"
 name             "circonus"


### PR DESCRIPTION
This is useful to do layering of more complicated monitoring schemes from a simple JSON doc.
