### PR TITLE
Resmon/NAD/JSON target exception handling

### DIFF
--- a/libraries/check_type_json.rb
+++ b/libraries/check_type_json.rb
@@ -10,7 +10,17 @@ class Circonus
       def all
         # Discovery via HTTP
         url = config[:url]
-        content = open(url).read
+
+        begin
+          content = open(url).read
+        rescue Errno::ETIMEDOUT
+          Chef::Log.warn("JSON at #{url} timed out. Returning empty metrics list.")
+          return Hash.new()
+        rescue Errno::ECONNREFUSED
+          Chef::Log.warn("JSON at #{url} did not respond. Returning empty metrics list.")
+          return Hash.new()
+        end
+
         data = ::JSON.parse(content)
 
         # From JSON Docs link on any Circonus Web UI check page

--- a/libraries/check_type_json.rb
+++ b/libraries/check_type_json.rb
@@ -11,6 +11,7 @@ class Circonus
         # Discovery via HTTP
         url = config[:url]
 
+        content = nil
         begin
           content = open(url).read
         rescue Errno::ETIMEDOUT

--- a/libraries/check_type_nad.rb
+++ b/libraries/check_type_nad.rb
@@ -22,6 +22,7 @@ class Circonus
         # TODO read SSL, path, etc from config
         url = "http://" + target + ":" + node[:nad][:port].to_s + '/'
 
+        content = nil
         begin
           content = open(url).read
         rescue Errno::ETIMEDOUT

--- a/libraries/check_type_resmon.rb
+++ b/libraries/check_type_resmon.rb
@@ -25,6 +25,7 @@ class Circonus
         # TODO read SSl, path, etc from config
         url = "http://" + target + ":" + node[:resmon][:port].to_s + '/'
 
+        xml = nil
         begin
           xml = open(url).read
         rescue Errno::ETIMEDOUT


### PR DESCRIPTION
Instead of terminating the Chef run with unhandled fatal exceptions, rescue ETIMEDOUT and ECONNREFUSED by emitting warnings to the Chef log and returning empty metric lists. These checks will fail frequently on an initial provision, because the target services will not yet be configured. But if the Chef run is terminating, the services can't be provisioned for a subsequent run either.
