### PR TITLE
Graph line style defaults to interpolated

### DIFF
--- a/providers/graph.rb
+++ b/providers/graph.rb
@@ -64,7 +64,7 @@ def init_empty_payload
     'datapoints' => [],
     'guides' => [],
     'style' => 'line',
-    'line_style' => nil
+    'line_style' => 'interpolated'
   }
   @new_resource.payload(payload)
 end

--- a/resources/graph.rb
+++ b/resources/graph.rb
@@ -7,7 +7,7 @@ attribute :max_right_y, :kind_of => Integer
 attribute :min_left_y, :kind_of => Integer
 attribute :min_right_y, :kind_of => Integer
 attribute :style, :kind_of => Symbol
-attribute :line_style, :kind_of => [Symbol, NilClass], :equal_to => [:stepped, :interpolated, nil], :default => nil
+attribute :line_style, :kind_of => [Symbol, NilClass], :equal_to => [:stepped, :interpolated], :default => :interpolated
 attribute :title, :kind_of => String, :name_attribute => true
 attribute :id
 attribute :tags, :kind_of => Array, :default => []


### PR DESCRIPTION
Turns out the API rejects the payload if line_style is null but there are datapoints. I think graphs default to interpolated anyways.
