### PR TITLE
Require/patch gems in a recipe context

### DIFF
--- a/libraries/check_type_json.rb
+++ b/libraries/check_type_json.rb
@@ -1,5 +1,3 @@
-require 'open-uri'
-require 'json'
 require File.expand_path(File.dirname(__FILE__) + '/check_type')
 
 class Circonus

--- a/libraries/check_type_nad.rb
+++ b/libraries/check_type_nad.rb
@@ -1,5 +1,3 @@
-require 'open-uri'
-require 'json'
 require File.expand_path(File.dirname(__FILE__) + '/check_type')
 
 class Circonus

--- a/libraries/check_type_resmon.rb
+++ b/libraries/check_type_resmon.rb
@@ -1,6 +1,3 @@
-require 'open-uri'
-require 'rexml/document' # missu nokogiri
-# require 'pp'
 require File.expand_path(File.dirname(__FILE__) + '/check_type')
 
 class Circonus

--- a/libraries/circonus_api.rb
+++ b/libraries/circonus_api.rb
@@ -24,12 +24,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-require 'json'
-require 'rest_client'
-require 'uri'
-require 'fileutils'
-
 if RUBY_VERSION =~ /^1\.8/
   class Dir
     class << self
@@ -37,17 +31,6 @@ if RUBY_VERSION =~ /^1\.8/
         File.directory?(path)
       end
       alias_method :exist?, :exists?
-    end
-  end
-end
-
-module RestClient
-  class Resource
-    unless self.method_defined?(:brackets_orig) then
-      alias :brackets_orig :"[]"    
-      def [](resource_name)
-        brackets_orig(URI.escape(resource_name))      
-      end
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,7 @@
 # node attributes
 
 chef_gem 'rest_client' do
-  compile_time true
-end
+end.run_action(:install)
 
 require 'json'
 require 'rest_client'
@@ -14,7 +13,7 @@ require 'fileutils'
 require 'open-uri'
 require 'rexml/document'
 
-module RestClient
+module ::RestClient
   class Resource
     unless self.method_defined?(:brackets_orig) then
       alias :brackets_orig :"[]"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,6 +3,27 @@
 # Register Circonus checks, metrics, and rules based on the contents of 
 # node attributes
 
+chef_gem 'rest_client' do
+  compile_time true
+end
+
+require 'json'
+require 'rest_client'
+require 'uri'
+require 'fileutils'
+require 'open-uri'
+require 'rexml/document'
+
+module RestClient
+  class Resource
+    unless self.method_defined?(:brackets_orig) then
+      alias :brackets_orig :"[]"
+      def [](resource_name)
+        brackets_orig(URI.escape(resource_name))
+      end
+    end
+  end
+end
 
 # This recipe is kinda stupid - just slavishly translates attribute structures into the equivalent resource structures.
 


### PR DESCRIPTION
I'm starting to use the chef standalone installation done by bahamas10 for SmartOS (http://us-east.manta.joyent.com/bahamas10/public/chef-standalone/index.html). This turns out not to have `rest_client` installed, so the require statements in the libraries fail.

This cookbook works again in the newer chef when we install `rest_client` with `chef_gem` and then move the require statements into the recipe context.
